### PR TITLE
Update to latest version of fire and tqdm

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-fire==0.1.3
+fire==0.2.1
 python-crfsuite==0.9.6
-tqdm==4.32.2
+tqdm==4.35.0


### PR DESCRIPTION
fire==0.2.1
tqdm==4.35.0

Nothing related to bug fixes or features, but more about removing version warnings when using with other libs.